### PR TITLE
Add Github Action winget-releaser

### DIFF
--- a/.github/workflows/release-winget.yml
+++ b/.github/workflows/release-winget.yml
@@ -1,0 +1,14 @@
+name: Winget Release
+on:
+  release:
+    types: [released]
+jobs:
+  publish:
+    runs-on: windows-latest
+    steps:
+      - uses: vedantmgoyal9/winget-releaser@main
+        with:
+          identifier: libvips.libvips
+          installers-regex: 'w64\-all*\.zip $' 
+          token: ${{ secrets.WINGET_TOKEN }}
+          # version: ${{ env.WINGET_TAG_NAME }}


### PR DESCRIPTION
This github action requires 
 - to create a Classic Github Token with `public_repo` scope is created, following [this link](https://github.com/settings/tokens/new)
 - to add the Token to the repo as a secret named `WINGET_ACC_TOKEN`.
 - See below, that user also will have to fork the winget-pkgs repository.

> Needs a classic GitHub token to submit PRs to winget-pkgs. This should be a classic token with the public_repo scope.
Whilst Komac can fully create manifests and commit with a fine-grained token, it fails to create a pull request to winget-pkgs. This may change as fine-grained tokens improve. See https://github.com/russellbanks/Komac/issues/310.